### PR TITLE
Map podcaster to CSL `host`

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2991,6 +2991,7 @@
 			"editor": "editor",
 			"guest": "guest",
 			"interviewer": "interviewer",
+			"podcaster": "host",
 			"producer": "producer",
 			"recipient": "recipient",
 			"reviewedAuthor": "reviewed-author",


### PR DESCRIPTION
See the examples of how a podcaster is cited in the [Chicago Citation Quick Guide](https://www.chicagomanualofstyle.org/tools_citationguide/citation-guide-1.html#cg-videos) and [APA style](https://apastyle.apa.org/style-grammar-guidelines/references/examples/podcast-references).