### PR TITLE
Add ISSN to additional item types

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -955,6 +955,9 @@
 					"field": "accessDate"
 				},
 				{
+					"field": "ISSN"
+				},
+				{
 					"field": "archive"
 				},
 				{
@@ -1183,6 +1186,9 @@
 				},
 				{
 					"field": "accessDate"
+				},
+				{
+					"field": "ISSN"
 				},
 				{
 					"field": "archive"
@@ -1798,9 +1804,6 @@
 					"field": "pages"
 				},
 				{
-					"field": "ISSN"
-				},
-				{
 					"field": "DOI"
 				},
 				{
@@ -1811,6 +1814,9 @@
 				},
 				{
 					"field": "accessDate"
+				},
+				{
+					"field": "ISSN"
 				},
 				{
 					"field": "archive"
@@ -2053,9 +2059,6 @@
 					"field": "pages"
 				},
 				{
-					"field": "ISSN"
-				},
-				{
 					"field": "DOI"
 				},
 				{
@@ -2066,6 +2069,9 @@
 				},
 				{
 					"field": "accessDate"
+				},
+				{
+					"field": "ISSN"
 				},
 				{
 					"field": "archive"
@@ -2723,6 +2729,9 @@
 				},
 				{
 					"field": "accessDate"
+				},
+				{
+					"field": "ISSN"
 				},
 				{
 					"field": "archive"


### PR DESCRIPTION
Ensure that ISSN fields appear on all print types for consistency with their addition to books and book chapters. Reorder field in magazines and newspapers to match journal articles. Examples:

- Dictionaries: <https://portal.issn.org/api/search?search[]=MUST=default=dictionary>
- Encyclopedias: <https://portal.issn.org/api/search?search[]=MUST=default=encyclopedia>
- Standards: <https://doi.org/10.3789/ansi.niso.z39.29-2005R2010>, <https://portal.issn.org/api/search?search[]=MUST=default=standards>