### PR TITLE
Add `narrator` to books and audio recordings

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -180,6 +180,9 @@
 					"creatorType": "wordsBy"
 				},
 				{
+					"creatorType": "narrator"
+				},
+				{
 					"creatorType": "translator"
 				},
 				{
@@ -433,6 +436,9 @@
 					"creatorType": "editor"
 				},
 				{
+					"creatorType": "narrator"
+				},
+				{
 					"creatorType": "translator"
 				},
 				{
@@ -549,6 +555,9 @@
 				},
 				{
 					"creatorType": "bookAuthor"
+				},
+				{
+					"creatorType": "narrator"
 				},
 				{
 					"creatorType": "translator"
@@ -2286,6 +2295,9 @@
 				},
 				{
 					"creatorType": "castMember"
+				},
+				{
+					"creatorType": "narrator"
 				},
 				{
 					"creatorType": "translator"


### PR DESCRIPTION
Allow a narrator for citing an audiobook. Usage examples:

- Audio recording: <https://www.zotero.org/groups/2205533/items/LJQ5S4FV>
- Books: <https://www.zotero.org/groups/2205533/items/SBF63UEN>, <https://www.zotero.org/groups/2205533/items/CCIVLNBS>, <https://www.zotero.org/groups/2205533/items/K6KFD7KD>