### PR TITLE
Add `interviewer` to additional item types

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -551,6 +551,9 @@
 					"creatorType": "bookAuthor"
 				},
 				{
+					"creatorType": "interviewer"
+				},
+				{
 					"creatorType": "translator"
 				},
 				{
@@ -1688,6 +1691,9 @@
 					"creatorType": "editor"
 				},
 				{
+					"creatorType": "interviewer"
+				},
+				{
 					"creatorType": "translator"
 				},
 				{
@@ -1844,6 +1850,9 @@
 				},
 				{
 					"creatorType": "contributor"
+				},
+				{
+					"creatorType": "interviewer"
 				},
 				{
 					"creatorType": "translator"
@@ -2101,6 +2110,9 @@
 					"creatorType": "contributor"
 				},
 				{
+					"creatorType": "interviewer"
+				},
+				{
 					"creatorType": "translator"
 				},
 				{
@@ -2268,6 +2280,9 @@
 				},
 				{
 					"creatorType": "guest"
+				},
+				{
+					"creatorType": "interviewer"
 				},
 				{
 					"creatorType": "producer"
@@ -2538,6 +2553,9 @@
 				},
 				{
 					"creatorType": "guest"
+				},
+				{
+					"creatorType": "interviewer"
 				},
 				{
 					"creatorType": "producer"
@@ -3019,6 +3037,9 @@
 					"creatorType": "guest"
 				},
 				{
+					"creatorType": "interviewer"
+				},
+				{
 					"creatorType": "narrator"
 				},
 				{
@@ -3199,6 +3220,9 @@
 				},
 				{
 					"creatorType": "contributor"
+				},
+				{
+					"creatorType": "interviewer"
 				},
 				{
 					"creatorType": "translator"


### PR DESCRIPTION
Add `interviewer` to articles and broadcast items. Usage examples:

- Book section: <https://www.zotero.org/groups/2205533/items/EPKB4ZW4>
- Journal article: <https://www.zotero.org/groups/2205533/items/CCKGR73D>, <https://www.zotero.org/groups/2205533/items/HLZX7VBX>
- Magazine article: <https://www.zotero.org/groups/2205533/items/MJKW9H9C>, <https://www.zotero.org/groups/2205533/items/XBE2CNSW>
- Radio broadcast: <https://www.zotero.org/groups/2205533/items/8NUJFXJ7>