### PR TITLE
Add `illustrator` creator type

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -436,6 +436,9 @@
 					"creatorType": "translator"
 				},
 				{
+					"creatorType": "illustrator"
+				},
+				{
 					"creatorType": "seriesEditor"
 				}
 			]
@@ -552,6 +555,9 @@
 				},
 				{
 					"creatorType": "translator"
+				},
+				{
+					"creatorType": "illustrator"
 				},
 				{
 					"creatorType": "seriesEditor"
@@ -3498,6 +3504,7 @@
 			"executiveProducer": "executive-producer",
 			"guest": "guest",
 			"host": "host",
+			"illustrator": "illustrator",
 			"interviewer": "interviewer",
 			"narrator": "narrator",
 			"originalCreator": "original-author",


### PR DESCRIPTION
Support CSL `illustrator` name. Usage examples: <https://www.zotero.org/groups/2205533/items/LAQGPVEM>, <https://www.zotero.org/groups/2205533/items/IFACCHV4>, <https://www.zotero.org/groups/2205533/items/923SWN5N>.