### PR TITLE
Blog post: Add publisher

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -286,6 +286,12 @@
 					"field": "date"
 				},
 				{
+					"field": "publisher"
+				},
+				{
+					"field": "place"
+				},
+				{
 					"field": "DOI"
 				},
 				{


### PR DESCRIPTION
Add publisher and publisher place fields to match web pages. Examples: <https://www.zotero.org/groups/2205533/items/HWZXMK5Y>, <https://www.zotero.org/groups/2205533/items/YXV868SP>.