### PR TITLE
Journal article: Add article number field

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1619,8 +1619,7 @@
 					"field": "pages"
 				},
 				{
-					"field": "identifier",
-					"baseField": "number"
+					"field": "number"
 				},
 				{
 					"field": "series"


### PR DESCRIPTION
An electronic article identifier/number needs to be stored in a separate field from page numbers to obtain correct results in APA and Chicago. These styles use the CSL <code>number</code> variable for this purpose. For example:

https://www.zotero.org/groups/2205533/items/GDNE6ZSD

https://www.zotero.org/groups/2205533/items/26QL7I8Y