### PR TITLE
Map `performer` field to CSL variable

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -3502,6 +3502,7 @@
 			"narrator": "narrator",
 			"originalCreator": "original-author",
 			"organizer": "organizer",
+			"performer": "performer",
 			"podcaster": "host",
 			"producer": "producer",
 			"recipient": "recipient",


### PR DESCRIPTION
Map the `performer` name type to the corresponding CSL `performer` variable rather than `author`. See <https://docs.citationstyles.org/en/stable/specification.html#name-variables>.