### PR TITLE
Use host as base field for podcaster creatorType

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2264,6 +2264,7 @@
 			"creatorTypes": [
 				{
 					"creatorType": "podcaster",
+					"baseField": "host",
 					"primary": true
 				},
 				{
@@ -3502,7 +3503,6 @@
 			"narrator": "narrator",
 			"originalCreator": "original-author",
 			"organizer": "organizer",
-			"podcaster": "host",
 			"producer": "producer",
 			"recipient": "recipient",
 			"reviewedAuthor": "reviewed-author",


### PR DESCRIPTION
Designate `host` as a base field for `podcaster` to ensure accurate transfer of information when changing types.